### PR TITLE
Clown Button Fix

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1037,7 +1037,7 @@
 	icon_state = "bigred"
 
 
-/obj/item/redbutton/attack_self(mob/user)
+/obj/item/redbutton/syndicate/attack_self(mob/user)
 	if (src.loc)
 		explosion(src.loc,0,2,3,flame_range = 3)
 		qdel(src)
@@ -1048,7 +1048,7 @@
 	name = "adminbus button"
 	desc = "adminbus much?"
 
-/obj/item/redbutton/attack_self(mob/user)
+/obj/item/redbutton/syndicate/adminbus/attack_self(mob/user)
 	if (src.loc)
 		explosion(src.loc,10,20,40,flame_range = 80)
 		qdel(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -915,6 +915,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	surplus = 1
 
+
+/datum/uplink_item/role_restricted/redbutton_syndicate
+	name = "The press of death"
+	desc = "A special button for a deadly prank. Pressing it makes the user explode! One-time use only. Do not press it yourself. Does not gib your target."
+	cost = 3
+	item = /obj/item/redbutton/syndicate
+	include_modes = list(/datum/game_mode/nuclear/clown_ops)
+
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"
@@ -1404,6 +1412,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 3
 	item = /obj/item/redbutton/syndicate
 	restricted_roles = list("Clown")
+
 
 
 /datum/uplink_item/role_restricted/ancient_jumpsuit


### PR DESCRIPTION
[Changelogs]: # 
:cl: 
fix: bug where pressing the clown button would use the adminbus detonation instead of the normal one
/:cl:

[why]: # Its just some darn fixes!
